### PR TITLE
パスワードリセットの説明文を追加しました

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -9,7 +9,7 @@ class PasswordResetsController < ApplicationController
     @user = User.find_by(email: params[:email])
     if @user
       UserMailer.reset_password_email(@user).deliver_later
-      redirect_to login_path, success: 'パスワードリセットのメールを送信しました。メールを確認してください。'
+      redirect_to login_path, success: 'パスワードリセットのメールを送信しました。メールをご確認してください。'
     else
       flash.now[:danger] = 'メールアドレスが見つかりませんでした。'
       render :new, status: :unprocessable_entity
@@ -32,9 +32,9 @@ class PasswordResetsController < ApplicationController
     @user.password_confirmation = params[:user][:password_confirmation]
 
     if @user.change_password(params[:user][:password])
-      redirect_to login_path, success: 'パスワードをリセットしました。新しいパスワードでログインしてください。'
+      redirect_to login_path, success: 'パスワードを変更しました。新しいパスワードでログインしてください。'
     else
-      flash.now[:danger] = 'パスワードのリセットに失敗しました。'
+      flash.now[:danger] = 'パスワードの変更に失敗しました。'
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="col-md-6 col-lg-4 mx-auto">
       <h1>🧸パスワードリセット</h1>
-      <p>登録したメールアドレスを入力してください。パスワードリセットの手順を記載したメールをお送りします。</p>
+      <p>パスワードを変更してください。変更が完了すると、新しいパスワードでログインできます。</p>
 
       <%= form_with model: @user, url: password_reset_path(@token), method: :patch, local: true do |f| %>
         <%= render 'shared/error_messages', object: @user %>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="col-md-6 col-lg-4 mx-auto">
       <h1>🧸 パスワードリセット</h1>
-      <p>登録したメールアドレスを入力してください。パスワードリセットの手順を記載したメールをお送りします。</p>
+      <p>登録したメールアドレスを入力してください。パスワードリセットの手順を記載したメールをお送りします。迷惑メールに入りやすいので、そちらもご確認ください。</p>
 
       <%= form_with url: password_resets_path, method: :post do |f| %>
         <%= render 'shared/error_messages', object: @user %>


### PR DESCRIPTION
パスワードリセットのところの説明文を追加しました。パスワード変更のメールについているリンクからアクセスできるページの文がおかしかったので直しました。